### PR TITLE
Fix sandbox canvas props and export filenames

### DIFF
--- a/components/(sandbox)/SandboxCanvas.tsx
+++ b/components/(sandbox)/SandboxCanvas.tsx
@@ -64,7 +64,7 @@ function Vehicle({ telemetry }: { telemetry: VehicleTelemetry }) {
   );
 }
 
-export function SandboxCanvas({ state, telemetry, watermark }: SandboxCanvasProps) {
+export function SandboxCanvas({ telemetry, watermark, containerRef }: SandboxCanvasProps) {
   const [dpr, setDpr] = useState(1);
 
   useEffect(() => {

--- a/components/(sandbox)/SandboxClient.tsx
+++ b/components/(sandbox)/SandboxClient.tsx
@@ -89,7 +89,7 @@ export function SandboxClient({ initialState, enable3D, isPro = false }: Sandbox
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `vehicelab-telemetry-${Date.now()}.csv`;
+    link.download = `vehiclelab-telemetry-${Date.now()}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -102,7 +102,7 @@ export function SandboxClient({ initialState, enable3D, isPro = false }: Sandbox
     const dataUrl = canvas.toDataURL('image/png');
     const link = document.createElement('a');
     link.href = dataUrl;
-    link.download = `vehicelab-snapshot-${Date.now()}.png`;
+    link.download = `vehiclelab-snapshot-${Date.now()}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);


### PR DESCRIPTION
## Summary
- fix SandboxCanvas props destructuring so the container ref is passed through correctly
- correct sandbox export filenames to use the VehicleLab name

## Testing
- npm run lint *(fails: next not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd80ab3220832c8eefc71d4e9add27