### PR TITLE
Fix Vercel build: remove @types/three, Contentlayer postinstall, npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "playwright test",
     "content": "contentlayer build",
     "prepare": "prisma generate",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate && contentlayer build",
     "lighthouse": "node scripts/lighthouse.mjs"
   },
   "dependencies": {
@@ -55,7 +55,6 @@
     "@types/node": "^20.11.30",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/three": "^0.167.4",
     "autoprefixer": "^10.4.18",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",


### PR DESCRIPTION
## Summary
- Removed `@types/three` because Three already includes its own TypeScript types
- Run Contentlayer during `postinstall` together with Prisma to ensure generated types exist in CI
- Added `.npmrc` with `legacy-peer-deps=true` so installs match Vercel defaults

## Testing
- `npm install` *(fails in container: npm registry returned 403 for @auth/prisma-adapter)*
- `npm run build` *(not run – install step failed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8785e1dc832ca25fc9c4933d8de9