### PR TITLE
Remove @types/three override to unblock Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
     "tailwindcss": "^3.4.10",
     "typescript": "^5.4.5"
   },
-  "overrides": {
-    "@types/three": "0.167.3"
-  },
   "engines": {
     "node": "20.x",
     "npm": "10.x"


### PR DESCRIPTION
## Summary
- remove the package.json overrides entry that pinned @types/three to a non-existent 0.167.3 release so installs stop failing with ETARGET
- confirm @types/three is not imported anywhere since three bundles its own type definitions, so no runtime code is affected

## Testing
- not run (not requested)

## After merge
- Vercel Settings → Build & Development:
  - Install Command: `npm install --no-audit --no-fund --legacy-peer-deps`
  - Build Command: `npm run build`
- Redeploy with cache cleared.


------
https://chatgpt.com/codex/tasks/task_e_68cd9f5d357c832c820db92b8a15b07d