### PR TITLE
Add MDX plugins required by Contentlayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.39",
     "prisma": "^5.17.0",
+    "rehype-autolink-headings": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^3.0.0",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.4.5"
   },


### PR DESCRIPTION
## Summary
- add rehype-autolink-headings, rehype-slug, and remark-gfm to the devDependencies list so Contentlayer has the MDX remark/rehype plugins it expects during postinstall

## Testing
- npm install *(fails: registry returns 403 for @auth/prisma-adapter via proxy, preventing lockfile update)*
- npx --yes contentlayer@0.3.4 build *(fails: registry returns 403 for contentlayer via proxy, so postinstall verification could not run)*

------
https://chatgpt.com/codex/tasks/task_e_68cda271cfa8832c83b1dcc89eaf2f62